### PR TITLE
Updating disqus script to support page identifier

### DIFF
--- a/templates/partial/disqus.html
+++ b/templates/partial/disqus.html
@@ -1,16 +1,21 @@
 {% if DISQUS_SITENAME %}
 <!-- Disqus -->
 <div id="disqus_thread"></div>
-<script type="text/javascript">
-    var disqus_shortname = '{{ DISQUS_SITENAME }}';
-    (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+
+<script>
+    var disqus_config = function () {
+        this.page.url = '{{ DISQUS_CANONICAL_HOST if DISQUS_CANONICAL_HOST else SITE_URL }}/{{ article.url }}';  // Replace PAGE_URL with your page's canonical URL variable
+        this.page.identifier = "{{ article.disqus_identifier if article.disqus_identifier else article.slug }}"; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
+    };
+
+    (function () { // DON'T EDIT BELOW THIS LINE
+        var d = document, s = d.createElement('script');
+        s.src = 'https://{{DISQUS_SITENAME}}.disqus.com/embed.js';
+        s.setAttribute('data-timestamp', +new Date());
+        (d.head || d.body).appendChild(s);
     })();
 </script>
-<noscript>
-    {{ _('Please enable JavaScript to view comments.') }}
-</noscript>
-<!-- End Disqus -->
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+
+<script id="dsq-count-scr" src="//{{DISQUS_SITENAME}}.disqus.com/count.js" async></script>
 {% endif %}


### PR DESCRIPTION
With these changes, it will be possible to use `disqus_identifier ` param in each article, and if it's not set, template will use `slug`. This will allow to change domain without issues.

🚨New config setting `DISQUS_CANONICAL_HOST` (not mandatory, it will use `SITE_URL` if it doesn't exist).